### PR TITLE
Spostati gli indicatori di array sul tipo 

### DIFF
--- a/src/it/unimi/di/prog2/t08/IntSetsClient.java
+++ b/src/it/unimi/di/prog2/t08/IntSetsClient.java
@@ -23,7 +23,7 @@ package it.unimi.di.prog2.t08;
 
 public class IntSetsClient {
 
-  public static void main(String args[]) {
+  public static void main(String[] args) {
     int[] a = new int[args.length];
     int i = 0;
     for (String s : args) a[i++] = Integer.parseInt(s);


### PR DESCRIPTION
Ciao

in Java è best practice mettere l'indicatore di array sul tipo e non sulla variabile, anche se entrambe le sintassi sono ammesse

ciao
matteo